### PR TITLE
Check if CustomEvent is defined, not if it is a function

### DIFF
--- a/tap.js
+++ b/tap.js
@@ -63,7 +63,7 @@
 
         if (!this.moved) {
             //create custom event
-            if (typeof CustomEvent === "function") {
+            if (typeof CustomEvent !== "undefined") {
                 evt = new CustomEvent('tap', {
                     bubbles: true,
                     cancelable: true


### PR DESCRIPTION
Safari for Mac (6.0.5) and Safari for iOS (6.1) both return
"object" for "typeof CustomEvent". As such, Tap.js previously
defaulted to the deprecated document.createEvent mechanism
event though Safari supports the new API.

![screen shot 2013-07-26 at 10 16 37](https://f.cloud.github.com/assets/243719/861296/3d2f11d6-f5cc-11e2-98f5-8eff589e6a91.png)
