### PR TITLE
Allow for event delegation to happen.

### DIFF
--- a/jquery.tap.js
+++ b/jquery.tap.js
@@ -28,5 +28,6 @@
                 
                 return false;
             }
+        };
     }());
 }(window.jQuery));


### PR DESCRIPTION
By returning `false` from the `setup` and `teardown` hooks we allow jQuery to automatically attach native event handlers on the element thus allowing for event delegation to work.
