### PR TITLE
Fix for IE11 not supporting CustomEvent constructor

### DIFF
--- a/tap.js
+++ b/tap.js
@@ -53,12 +53,14 @@
 
         if (!this.moved) {
             //create custom event
-            if (window.CustomEvent) {
+            if (typeof window.CustomEvent === 'function') {
+                //handle modern browsers
                 evt = new window.CustomEvent('tap', {
                     bubbles: true,
                     cancelable: true
                 });
             } else {
+                //handle older browsers and IE<=11
                 evt = document.createEvent('Event');
                 evt.initEvent('tap', true, true);
             }


### PR DESCRIPTION
This fixes an error in IE11, where `window.CustomEvent` is present, for whatever reason, but defined as an object (see http://msdn.microsoft.com/en-us/library/ie/ff974338%28v=vs.85%29.aspx).
