### PR TITLE
Switch CustomEvent check/fallback to try-catch

### DIFF
--- a/tap.js
+++ b/tap.js
@@ -64,12 +64,12 @@
 
         if (!this.moved) {
             //create custom event
-            if (window.CustomEvent) {
+            try {
                 evt = new window.CustomEvent('tap', {
                     bubbles: true,
                     cancelable: true
                 });
-            } else {
+            } catch (e) {
                 evt = document.createEvent('Event');
                 evt.initEvent('tap', true, true);
             }


### PR DESCRIPTION
I ran into a problem in IE10/11. The browser *does* have `window.CustomEvent()`, but it doesn't work as expected. Calling `new window.CustomEvent('tap')` produces an error: `Object does not support this action.`

Searching around I found that others had the same problem: https://github.com/sindresorhus/devtools-detect/issues/9

I found this custom-event-polyfill module that must use try-catch (instead of if-else) for this very reason: https://github.com/krambuhl/custom-event-polyfill/blob/master/custom-event-polyfill.js

So I used the try-catch here, and with that simple change I got the event working in IE10, and it is still working in the other browsers I've checked (though I don't have access to as many as are mentioned in the README).

Does this seem to you like a valid fix?

(Another alternative would be to use the short CustomEvent polyfill from MDN: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)

Thanks!