### PR TITLE
helper functions to convert onclick to use Tap.js

### DIFF
--- a/tap.js
+++ b/tap.js
@@ -29,45 +29,45 @@
         this.el.addEventListener('mousedown', this, false);
     }
 
-    function fixupMouse( event ) {
-        event = event || window.event;
-        var e = { event: event,
-            target: 'target' in event ? event.target : event.srcElement,
-            which: 'which' in event ? event.which : // otherwise MSIE<8
-                 event.button === 1 ? 1 :   // left
-                 event.button === 2 ? 3 :   // right
-                 event.button === 4 ? 2 : 1,// center
-            buttons: 0,
-            button: 0,
-            x: 'x' in event ? event.x : event.clientX,
-            y: 'y' in event ? event.y : event.clientY
-        };
-        e.button = e.which - 1;
-        e.buttons = 'buttons' in event ? event.buttons :
-                 e.which === 1 ? 1 :   // left
-                 e.which === 3 ? 2 :   // right
-                 e.which === 2 ? 4 : 1;// center
-        return e;
+    // query which button was pressed in the event
+    // handles many browsers/versions
+    // returns: 1=left, 2=right, 4=center, 8=4th, 16=5th
+    Tap.prototype.whichbutton = function(event) {
+        // modern & preferred:  MSIE>=9, Firefox(all)
+        if ('buttons' in event) {
+           // http://www.w3schools.com/jsref/event_buttons.asp
+           return event.buttons;  // 1=left,2=right,4=center,8=4th,16=5th
+        } else {
+           return 'which' in event ?
+               // 'which' is well defined (and doesn't exist on MSIE<=8)
+               // http://www.w3schools.com/jsref/event_which.asp
+               (event.which === 1 ? 1 :      // left
+                event.which === 3 ? 2 :      // right
+                event.which === 2 ? 4 : 1) : // center
+
+               // for MSIE<=8 button is 1=left,2=right,4=center (normally 0,2,1)
+               // http://www.w3schools.com/jsref/event_button.asp
+               event.button;
+        }
     }
 
     Tap.prototype.start = function(e) {
-        e = fixupMouse(e);
-        if (e.event.type === 'touchstart') {
+        if (e.type === 'touchstart') {
 
             this.hasTouchEventOccured = true;
             this.el.addEventListener('touchmove', this, false);
             this.el.addEventListener('touchend', this, false);
             this.el.addEventListener('touchcancel', this, false);
 
-        } else if (e.event.type === 'mousedown' && e.button == 0) {
+        } else if (e.type === 'mousedown' && this.whichbutton(e) === 1) {
 
             this.el.addEventListener('mousemove', this, false);
             this.el.addEventListener('mouseup', this, false);
         }
 
         this.moved = false;
-        this.startX = e.event.type === 'touchstart' ? e.event.touches[0].clientX : e.event.clientX;
-        this.startY = e.event.type === 'touchstart' ? e.event.touches[0].clientY : e.event.clientY;
+        this.startX = e.type === 'touchstart' ? e.touches[0].clientX : e.clientX;
+        this.startY = e.type === 'touchstart' ? e.touches[0].clientY : e.clientY;
     };
 
     Tap.prototype.move = function(e) {

--- a/tap.js
+++ b/tap.js
@@ -29,24 +29,45 @@
         this.el.addEventListener('mousedown', this, false);
     }
 
-    Tap.prototype.start = function(e) {
+    function fixupMouse( event ) {
+        event = event || window.event;
+        var e = { event: event,
+            target: 'target' in event ? event.target : event.srcElement,
+            which: 'which' in event ? event.which : // otherwise MSIE<8
+                 event.button === 1 ? 1 :   // left
+                 event.button === 2 ? 3 :   // right
+                 event.button === 4 ? 2 : 1,// center
+            buttons: 0,
+            button: 0,
+            x: 'x' in event ? event.x : event.clientX,
+            y: 'y' in event ? event.y : event.clientY
+        };
+        e.button = e.which - 1;
+        e.buttons = 'buttons' in event ? event.buttons :
+                 e.which === 1 ? 1 :   // left
+                 e.which === 3 ? 2 :   // right
+                 e.which === 2 ? 4 : 1;// center
+        return e;
+    }
 
-        if (e.type === 'touchstart') {
+    Tap.prototype.start = function(e) {
+        e = fixupMouse(e);
+        if (e.event.type === 'touchstart') {
 
             this.hasTouchEventOccured = true;
             this.el.addEventListener('touchmove', this, false);
             this.el.addEventListener('touchend', this, false);
             this.el.addEventListener('touchcancel', this, false);
 
-        } else if (e.type === 'mousedown' && e.button == 0) {
+        } else if (e.event.type === 'mousedown' && e.button == 0) {
 
             this.el.addEventListener('mousemove', this, false);
             this.el.addEventListener('mouseup', this, false);
         }
 
         this.moved = false;
-        this.startX = e.type === 'touchstart' ? e.touches[0].clientX : e.clientX;
-        this.startY = e.type === 'touchstart' ? e.touches[0].clientY : e.clientY;
+        this.startX = e.event.type === 'touchstart' ? e.event.touches[0].clientX : e.event.clientX;
+        this.startY = e.event.type === 'touchstart' ? e.event.touches[0].clientY : e.event.clientY;
     };
 
     Tap.prototype.move = function(e) {
@@ -122,4 +143,5 @@
 
     return Tap;
 }));
+
 

--- a/tap.js
+++ b/tap.js
@@ -123,33 +123,3 @@
     return Tap;
 }));
 
-/* generic helper for calling a function on every node in the DOM */
-function traverseDOMTree(currentElement, doSomething) {
-if (currentElement) {
-    var i=0;
-    var currentElementChild=currentElement.childNodes[i];
-          while (currentElementChild) {
-            doSomething(currentElementChild);
-            traverseDOMTree(currentElementChild, doSomething);
-            i++;
-            currentElementChild = currentElement.childNodes[i];
-        }
-    }
-}
-
-/* convert a single object's onclick attrib to also support touch */
-function convertToTappable(obj) {
-    if (obj.hasAttribute !== undefined && obj.hasAttribute("onclick")) {
-        obj.ontap = obj.onclick.toString();
-        var myTap = new Tap(obj);
-        obj.addEventListener('tap', obj.onclick, false);
-        obj.removeAttribute("onclick");
-    }
-}
-
-/* convert entire DOM tree onclick attribs to instead use Tap.js */
-function convertAllonclick2ontap() {
-    // convert all onclicks to also be tappable
-    traverseDOMTree(document, function(node){ convertToTappable( node ); });
-}
-

--- a/tap.js
+++ b/tap.js
@@ -29,26 +29,23 @@
         this.el.addEventListener('mousedown', this, false);
     }
 
-    // query which button was pressed in the event
-    // handles many browsers/versions
-    // returns: 1=left, 2=right, 4=center, 8=4th, 16=5th
-    Tap.prototype.whichbutton = function(event) {
+    // return true if left click is in the event, handle many browsers
+    Tap.prototype.leftButton = function(event) {
         // modern & preferred:  MSIE>=9, Firefox(all)
         if ('buttons' in event) {
-           // http://www.w3schools.com/jsref/event_buttons.asp
-           return event.buttons;  // 1=left,2=right,4=center,8=4th,16=5th
+           // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons
+           return event.buttons === 1;
         } else {
            return 'which' in event ?
                // 'which' is well defined (and doesn't exist on MSIE<=8)
-               // http://www.w3schools.com/jsref/event_which.asp
-               (event.which === 1 ? 1 :      // left
-                event.which === 3 ? 2 :      // right
-                event.which === 2 ? 4 : 1) : // center
+               // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/which
+               event.which === 1 :
 
-               // for MSIE<=8 button is 1=left,2=right,4=center (normally 0,2,1)
-               // http://www.w3schools.com/jsref/event_button.asp
-               event.button;
+               // for MSIE<=8 button is 1=left (0 on all other browsers)
+               // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+               event.button === 1;
         }
+        return false;
     }
 
     Tap.prototype.start = function(e) {
@@ -59,7 +56,7 @@
             this.el.addEventListener('touchend', this, false);
             this.el.addEventListener('touchcancel', this, false);
 
-        } else if (e.type === 'mousedown' && this.whichbutton(e) === 1) {
+        } else if (e.type === 'mousedown' && this.leftButton(e)) {
 
             this.el.addEventListener('mousemove', this, false);
             this.el.addEventListener('mouseup', this, false);


### PR DESCRIPTION
hi, i have the following enhancements to Tap.js

1.) support mouse move (for when selecting text, it will then not register the "tap", this provides parity with touchmove cancellation of taps which you already had in Tap.js...).

2.) add methods for converting existing app full of "onclick" events to use Tap.js for both click/tap ability...  (basically all I really wanted is a new "ontap" event which recognized both mouse/touch, or for onclick to recognize tap events in addition...  these new methods give me that)...

I would be interested in your opinion about the below methods.   My motivation for this was that I was disappointed to find that there was no built in "ontap" in the language which handles both click and tap...  So I tried to write that using your Tap.js.  My approach is to convert any appearance of "onclick" to Tap.js (which should then support both).   What I wished for was that javascript would support a new event callback "ontap", or add tap events to onclick.